### PR TITLE
FEATURE/MEDIUM: cookie: added better support for cookie

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -271,7 +271,7 @@ definitions:
           type: string
           x-display-name: Continuous Statistics
         cookie:
-          type: string
+          $ref: '#/definitions/cookie'
         default_backend:
           pattern: ^[A-Za-z0-9-_.:]+$
           type: string
@@ -536,7 +536,7 @@ definitions:
           type: integer
           x-nullable: true
         cookie:
-          type: string
+          $ref: '#/definitions/cookie'
           x-dependency:
             mode:
               value: http
@@ -2671,6 +2671,45 @@ definitions:
           type: string
       type: object
       x-display-name: Error File
+  cookie:
+      properties:
+        domain:
+          items:
+            pattern: ^[^\s]+$
+            type: string
+          type: array
+        dynamic:
+          type: boolean
+        httponly:
+          type: boolean
+        indirect:
+          type: boolean
+        maxidle:
+          pattern: ^[^\d+$]
+          type: integer
+        maxlife:
+          pattern: ^[^\d+$]
+          type: integer
+        name:
+          pattern: ^[^\s]+$
+          type: string
+        nocache:
+          type: boolean
+        postonly:
+          type: boolean
+        preserve:
+          type: boolean
+        secure:
+          type: boolean
+        type:
+          enum:
+          - rewrite
+          - insert
+          - prefix
+          type: string
+      required:
+      - name
+      type: object
 responses:
   BadRequest:
     description: Bad request

--- a/haproxy-spec.yaml
+++ b/haproxy-spec.yaml
@@ -188,6 +188,8 @@ definitions:
     $ref: "models/haproxy.yaml#/redispatch"
   errorfile:
     $ref: "models/haproxy.yaml#/errorfile"
+  cookie:
+    $ref: "models/haproxy.yaml#/cookie"
 responses:
   BadRequest:
     description: Bad request

--- a/models/haproxy.yaml
+++ b/models/haproxy.yaml
@@ -150,7 +150,7 @@ defaults:
       enum: [enabled]
       x-display-name: Continuous Statistics
     cookie:
-      type: string
+      $ref: '#/definitions/cookie'
     client_timeout:
       type: integer
       x-nullable: true
@@ -356,7 +356,7 @@ backend:
         mode:
           value: http
     cookie:
-      type: string
+      $ref: '#/definitions/cookie'
       x-dependency: 
         mode: 
           value: http 
@@ -1428,3 +1428,39 @@ errorfile:
       enum: [200, 400, 403, 405, 408, 425, 429, 500, 502, 503, 504]
     file:
       type: string
+cookie:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      pattern: '^[^\s]+$'
+    type:
+      type: string
+      enum: [rewrite, insert, prefix]
+    indirect:
+      type: boolean
+    nocache:
+      type: boolean
+    postonly:
+      type: boolean
+    preserve:
+      type: boolean
+    httponly:
+      type: boolean
+    secure:
+      type: boolean
+    domain:
+      type: array
+      items:
+        type: string
+        pattern: '^[^\s]+$'
+    maxidle:
+      type: integer
+      pattern: '^[^\d+$]'
+    maxlife:
+      type: integer
+      pattern: '^[^\d+$]'
+    dynamic:
+      type: boolean


### PR DESCRIPTION
Cookie object presentation changed for backend & defaults section to support valid options https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#cookie%20(Alphabetically%20sorted%20keywords%20reference). Currently any string is accepted.