### PR TITLE
DOC/MINOR: fix forwardfor example in response samples for add backend

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -508,7 +508,7 @@ definitions:
         balance:
           algorithm: roundrobin
         forwardfor:
-          enabled: true
+          enabled: enabled
         httpchk:
           method: OPTIONS
           uri: /check

--- a/models/configuration.yaml
+++ b/models/configuration.yaml
@@ -450,7 +450,7 @@ backend:
     balance: 
       algorithm: roundrobin
     forwardfor: 
-      enabled: true
+      enabled: enabled
     httpchk: 
       uri: "/check"
       method: OPTIONS


### PR DESCRIPTION
Hello.

There is a mistake in the specification file: https://www.haproxy.com/documentation/dataplaneapi/latest/#operation/createBackend .
The anchor should lead you to the right spot on the html page, it states: 
```
"forwardfor": {
"enabled": true
},
```
But it should be `"enabled": "enabled"` to matchthe string enum expected.

I figured it out when I put the string "true" and got: `{'code': 606, 'message': 'enabled in body should be one of [enabled]'}`.

