### PR TITLE
MINOR: server: add proto option

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -16,10 +16,11 @@ externalDocs:
 definitions:
   site:
       additionalProperties: false
-      description: "Site configuration. Sites are considered as one service and all farms
-        connected to that service.\nFarms are connected to service using use-backend and
-        default_backend directives. Sites let you\nconfigure simple HAProxy configurations,
-        for more advanced options use /haproxy/configuration \nendpoints.\n"
+      description: |
+        Site configuration. Sites are considered as one service and all farms connected to that service.
+        Farms are connected to service using use-backend and default_backend directives. Sites let you
+        configure simple HAProxy configurations, for more advanced options use /haproxy/configuration
+        endpoints.
       example:
         farms:
         - balance:
@@ -823,6 +824,9 @@ definitions:
           minimum: 1
           type: integer
           x-nullable: true
+        proto:
+          pattern: ^[^\s]+$
+          type: string
         send-proxy:
           enum:
           - enabled

--- a/models/haproxy.yaml
+++ b/models/haproxy.yaml
@@ -559,6 +559,9 @@ server:
     check:
       type: string
       enum: [enabled, disabled]
+    proto:
+      type: string
+      pattern: '^[^\s]+$'
     maintenance:
       type: string
       enum: [enabled, disabled]


### PR DESCRIPTION
The server spec didn't include the option `proto` as documented [here](https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#5.2-proto)