### PR TITLE
MINOR: server: adds slowstart parameter

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -1050,6 +1050,9 @@ definitions:
           - enabled
           - disabled
           type: string
+        slowstart:
+          pattern: ^[1-9][0-9]*(us|ms|s|m|h|d)$
+          type: string
         sni:
           pattern: ^[^\s]+$
           type: string

--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -1051,8 +1051,8 @@ definitions:
           - disabled
           type: string
         slowstart:
-          pattern: ^[1-9][0-9]*(us|ms|s|m|h|d)$
-          type: string
+          type: integer
+          x-nullable: true
         sni:
           pattern: ^[^\s]+$
           type: string
@@ -3740,6 +3740,9 @@ definitions:
             operation: getResolvers
             property: name
         rise:
+          type: integer
+          x-nullable: true
+        slowstart:
           type: integer
           x-nullable: true
         sni:

--- a/models/configuration.yaml
+++ b/models/configuration.yaml
@@ -799,8 +799,8 @@ server:
       type: string
       enum: [enabled, disabled]
     slowstart:
-      type: string
-      pattern: '^[1-9][0-9]*(us|ms|s|m|h|d)$'
+      type: integer
+      x-nullable: true
     sni:
       type: string
       pattern: '^[^\s]+$'
@@ -1872,6 +1872,9 @@ default_server:
     check-sni:
       type: string
       pattern: '^[^\s]+$'
+    slowstart:
+      type: integer
+      x-nullable: true
     sni:
       type: string
       pattern: '^[^\s]+$'

--- a/models/configuration.yaml
+++ b/models/configuration.yaml
@@ -798,6 +798,9 @@ server:
     send-proxy-v2:
       type: string
       enum: [enabled, disabled]
+    slowstart:
+      type: string
+      pattern: '^[1-9][0-9]*(us|ms|s|m|h|d)$'
     sni:
       type: string
       pattern: '^[^\s]+$'


### PR DESCRIPTION
Adds support for slowstart parameter to server configuration part of the dataplaneapi specification.
Related: https://github.com/haproxytech/models/pull/16