### PR TITLE
MINOR: server: add proxy-v2-options

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -1040,6 +1040,19 @@ definitions:
         proto:
           pattern: ^[^\s]+$
           type: string
+        proxy-v2-options:
+          items:
+            enum:
+            - ssl
+            - cert-cn
+            - ssl-cipher
+            - cert-sig
+            - cert-key
+            - authority
+            - crc32c
+            - unique-id
+            type: string
+          type: array
         resolve-net:
           pattern: ^[^\s]+$
           type: string

--- a/models/configuration.yaml
+++ b/models/configuration.yaml
@@ -811,6 +811,11 @@ server:
     send-proxy-v2:
       type: string
       enum: [enabled, disabled]
+    proxy-v2-options:
+      type: array
+      items:
+        type: string
+        enum: [ssl, cert-cn, ssl-cipher, cert-sig, cert-key, authority, crc32c, unique-id]
     slowstart:
       type: integer
       x-nullable: true


### PR DESCRIPTION
proxy-v2-options instructs haproxy to set TLV attributes in forwarded PROXYv2 connections.

cf. http://cbonte.github.io/haproxy-dconv/2.2/configuration.html#5.2