### PR TITLE
Fix per https://github.com/haproxytech/dataplaneapi/issues/147

### DIFF
--- a/build/haproxy_spec.yaml
+++ b/build/haproxy_spec.yaml
@@ -2315,6 +2315,8 @@ definitions:
           - 301
           - 302
           - 303
+          - 307
+          - 308
           type: integer
           x-dependency:
             type:

--- a/models/configuration.yaml
+++ b/models/configuration.yaml
@@ -1745,7 +1745,7 @@ http_response_rule:
       type: integer
       x-nullable: true
       x-display-name: Redirect Code
-      enum: [301, 302, 303]
+      enum: [301, 302, 303, 307, 308]
       x-dependency:
         type:
           value: redirect


### PR DESCRIPTION
I've made this change locally, rebuild the dataplaneapi binary using the changed spec file and indeed the issue here:
https://github.com/haproxytech/dataplaneapi/issues/147

is solved. 307 redirects are created without error.